### PR TITLE
Added try/except to average rating to prevent ZeroDivisionError

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -59,10 +59,14 @@ class Product(SafeDeleteModel):
         """
         ratings = ProductRating.objects.filter(product=self)
         total_rating = 0
-        for rating in ratings:
-            total_rating += rating.rating
+        try:
+            for rating in ratings:
+                total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
+            avg = total_rating / len(ratings)
+            return avg
+        except ZeroDivisionError:
+            avg = 0
         return avg
 
     class Meta:


### PR DESCRIPTION
This pull request addresses issue [#18](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/18), where the server responds with a status code of 500 and a "division by zero" error message when a client requests a single product or all products. The issue arises due to an unhandled ZeroDivisionError when calculating the average rating for products with no ratings.

## Changes

- Implemented try/except blocks to handle ZeroDivisionError in the calculation of average product ratings.
- Modified the code to return an average rating of 0 for products with no ratings.

## Requests / Responses

### Retrieve All Products

**Request**

GET /products

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Seoul",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0
    },
    {
        "id": 2,
        "name": "Golf",
        "price": 653.59,
        "number_sold": 0,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Paris",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0
    }, 
    ...
]
```

### Retrieve a Single Product

**Request**

GET /products/1

**Response**

HTTP/1.1 200 OK

```json
    {
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Seoul",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0
    }
```
## Testing

To test code...

- [x] Open Postman
- [x] Make sure you include an Authorization header with a Token of one of your users
- [x]  Send the GET requests to the appropriate endpoints (`/products` to retrieve all products, and `/products/{id}` to retrieve a single product).
- [x] Ensure that the "division by zero" error is no longer present in the responses.
- [x] Verify that the response for each request is similar to the responses shown above.


## Related Issues

- Fixes [#18](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/18)
