### PR TITLE
Heidel/bug/cart/has duplicate items/api

### DIFF
--- a/bangazonapi/models/orderproduct.py
+++ b/bangazonapi/models/orderproduct.py
@@ -4,9 +4,9 @@ from django.db import models
 class OrderProduct(models.Model):
 
     order = models.ForeignKey(
-        "Order", on_delete=models.DO_NOTHING, related_name="lineitems"
+        "Order", on_delete=models.DO_NOTHING, related_name="line_items"
     )
 
     product = models.ForeignKey(
-        "Product", on_delete=models.DO_NOTHING, related_name="lineitems"
+        "Product", on_delete=models.DO_NOTHING, related_name="line_items"
     )

--- a/bangazonapi/models/orderproduct.py
+++ b/bangazonapi/models/orderproduct.py
@@ -4,9 +4,9 @@ from django.db import models
 class OrderProduct(models.Model):
 
     order = models.ForeignKey(
-        "Order", on_delete=models.DO_NOTHING, related_name="line_items"
+        "Order", on_delete=models.DO_NOTHING, related_name="lineitems"
     )
 
     product = models.ForeignKey(
-        "Product", on_delete=models.DO_NOTHING, related_name="line_items"
+        "Product", on_delete=models.DO_NOTHING, related_name="lineitems"
     )

--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -1,4 +1,5 @@
 """View module for handling requests about customer shopping cart"""
+
 import datetime
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
@@ -25,7 +26,8 @@ class Cart(ViewSet):
 
         try:
             open_order = Order.objects.get(
-                customer=current_user, payment_type__isnull=True)
+                customer=current_user, payment_type__isnull=True
+            )
         except Order.DoesNotExist as ex:
             open_order = Order()
             open_order.created_date = datetime.datetime.now()
@@ -39,7 +41,6 @@ class Cart(ViewSet):
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 
-
     def destroy(self, request, pk=None):
         """
         @api {DELETE} /cart/:id DELETE line item from cart
@@ -51,17 +52,12 @@ class Cart(ViewSet):
             HTTP/1.1 204 No Content
         """
         current_user = Customer.objects.get(user=request.auth.user)
-        open_order = Order.objects.get(
-            customer=current_user, payment_type=None)
+        open_order = Order.objects.get(customer=current_user, payment_type=None)
 
-        line_item = OrderProduct.objects.filter(
-            product__id=pk,
-            order=open_order
-        )[0]
+        line_item = OrderProduct.objects.filter(product__id=pk, order=open_order)[0]
         line_item.delete()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
-
 
     def list(self, request):
         """
@@ -75,9 +71,9 @@ class Cart(ViewSet):
         @apiSuccess (200) {Object} payment_type Payment id use to complete order
         @apiSuccess (200) {String} customer URI for customer
         @apiSuccess (200) {Number} size Number of items in cart
-        @apiSuccess (200) {Object[]} line_items Line items in cart
-        @apiSuccess (200) {Number} line_items.id Line item id
-        @apiSuccess (200) {Object} line_items.product Product in cart
+        @apiSuccess (200) {Object[]} lineitems Line items in cart
+        @apiSuccess (200) {Number} lineitems.id Line item id
+        @apiSuccess (200) {Object} lineitems.product Product in cart
         @apiSuccessExample {json} Success
             {
                 "id": 2,
@@ -109,25 +105,23 @@ class Cart(ViewSet):
         """
         current_user = Customer.objects.get(user=request.auth.user)
         try:
-            open_order = Order.objects.get(
-                customer=current_user, payment_type=None)
+            open_order = Order.objects.get(customer=current_user, payment_type=None)
 
-            products_on_order = Product.objects.filter(
-                lineitems__order=open_order)
+            products_on_order = Product.objects.filter(lineitems__order=open_order)
 
             serialized_order = OrderSerializer(
-                open_order, many=False, context={'request': request})
+                open_order, many=False, context={"request": request}
+            )
 
             product_list = ProductSerializer(
-                products_on_order, many=True, context={'request': request})
+                products_on_order, many=True, context={"request": request}
+            )
 
-            final = {
-                "order": serialized_order.data
-            }
+            final = {"order": serialized_order.data}
             final["order"]["products"] = product_list.data
             final["order"]["size"] = len(products_on_order)
 
         except Order.DoesNotExist as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
         return Response(final["order"])

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -19,7 +19,7 @@ class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = OrderProduct
         url = serializers.HyperlinkedIdentityField(
-            view_name="lineitem", lookup_field="id"
+            view_name="line_item", lookup_field="id"
         )
         fields = ("id", "product")
         depth = 1
@@ -28,7 +28,7 @@ class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
 class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
 
-    lineitems = OrderLineItemSerializer(many=True)
+    line_items = OrderLineItemSerializer(many=True)
     total = serializers.SerializerMethodField()
 
     """Define a SerializerMethodField to represent payment_type by its name"""
@@ -44,12 +44,12 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
             "payment_type_name",  # Use the SerializerMethodField instead of payment_type
             "customer",
             "total",
-            "lineitems",
+            "line_items",
         )
 
     def get_total(self, obj):
         total = 0
-        for item in obj.lineitems.all():
+        for item in obj.line_items.all():
             total += item.product.price
         return total
 

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -28,7 +28,7 @@ class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
 class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
 
-    line_items = OrderLineItemSerializer(many=True)
+    lineitems = OrderLineItemSerializer(many=True)
     total = serializers.SerializerMethodField()
 
     """Define a SerializerMethodField to represent payment_type by its name"""
@@ -44,12 +44,12 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
             "payment_type_name",  # Use the SerializerMethodField instead of payment_type
             "customer",
             "total",
-            "line_items",
+            "lineitems",
         )
 
     def get_total(self, obj):
         total = 0
-        for item in obj.line_items.all():
+        for item in obj.lineitems.all():
             total += item.product.price
         return total
 

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -1,4 +1,5 @@
 """View module for handling requests about customer profiles"""
+
 import datetime
 from django.http import HttpResponseServerError
 from django.contrib.auth.models import User
@@ -16,6 +17,7 @@ from .order import OrderSerializer
 
 class Profile(ViewSet):
     """Request handlers for user profile info in the Bangazon Platform"""
+
     permission_classes = (IsAuthenticatedOrReadOnly,)
 
     def list(self, request):
@@ -82,16 +84,19 @@ class Profile(ViewSet):
         """
         try:
             current_user = Customer.objects.get(user=4)
-            current_user.recommends = Recommendation.objects.filter(recommender=current_user)
+            current_user.recommends = Recommendation.objects.filter(
+                recommender=current_user
+            )
 
             serializer = ProfileSerializer(
-                current_user, many=False, context={'request': request})
+                current_user, many=False, context={"request": request}
+            )
 
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)
 
-    @action(methods=['get', 'post', 'delete'], detail=False)
+    @action(methods=["get", "post", "delete"], detail=False)
     def cart(self, request):
         """Shopping cart manipulation"""
 
@@ -112,13 +117,14 @@ class Profile(ViewSet):
             @apiError (404) {String} message  Not found message.
             """
             try:
-                open_order = Order.objects.get(
-                    customer=current_user, payment_type=None)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
                 line_items.delete()
                 open_order.delete()
             except Order.DoesNotExist as ex:
-                return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+                return Response(
+                    {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
+                )
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
@@ -175,20 +181,23 @@ class Profile(ViewSet):
             @apiError (404) {String} message  Not found message
             """
             try:
-                open_order = Order.objects.get(
-                    customer=current_user, payment_type=None)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
                 line_items = LineItemSerializer(
-                    line_items, many=True, context={'request': request})
+                    line_items, many=True, context={"request": request}
+                )
 
                 cart = {}
-                cart["order"] = OrderSerializer(open_order, many=False, context={
-                                                'request': request}).data
+                cart["order"] = OrderSerializer(
+                    open_order, many=False, context={"request": request}
+                ).data
                 cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:
-                return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+                return Response(
+                    {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
+                )
 
             return Response(cart["order"])
 
@@ -243,19 +252,19 @@ class Profile(ViewSet):
                 open_order.save()
 
             line_item = OrderProduct()
-            line_item.product = Product.objects.get(
-                pk=request.data["product_id"])
+            line_item.product = Product.objects.get(pk=request.data["product_id"])
             line_item.order = open_order
             line_item.save()
 
             line_item_json = LineItemSerializer(
-                line_item, many=False, context={'request': request})
+                line_item, many=False, context={"request": request}
+            )
 
             return Response(line_item_json.data)
 
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    @action(methods=['get'], detail=False)
+    @action(methods=["get"], detail=False)
     def favoritesellers(self, request):
         """
         @api {GET} /profile/favoritesellers GET favorite sellers
@@ -307,7 +316,8 @@ class Profile(ViewSet):
         favorites = Favorite.objects.filter(customer=customer)
 
         serializer = FavoriteSerializer(
-            favorites, many=True, context={'request': request})
+            favorites, many=True, context={"request": request}
+        )
         return Response(serializer.data)
 
 
@@ -317,11 +327,12 @@ class LineItemSerializer(serializers.HyperlinkedModelSerializer):
     Arguments:
         serializers
     """
+
     product = ProductSerializer(many=False)
 
     class Meta:
         model = OrderProduct
-        fields = ('id', 'product')
+        fields = ("id", "product")
         depth = 1
 
 
@@ -331,36 +342,49 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
     Arguments:
         serializers
     """
+
     class Meta:
         model = User
-        fields = ('first_name', 'last_name', 'email')
+        fields = ("first_name", "last_name", "email")
         depth = 1
 
 
 class CustomerSerializer(serializers.ModelSerializer):
     """JSON serializer for recommendation customers"""
+
     user = UserSerializer()
 
     class Meta:
         model = Customer
-        fields = ('id', 'user',)
+        fields = (
+            "id",
+            "user",
+        )
 
 
 class ProfileProductSerializer(serializers.ModelSerializer):
     """JSON serializer for products"""
+
     class Meta:
         model = Product
-        fields = ('id', 'name',)
+        fields = (
+            "id",
+            "name",
+        )
 
 
 class RecommenderSerializer(serializers.ModelSerializer):
     """JSON serializer for recommendations"""
+
     customer = CustomerSerializer()
     product = ProfileProductSerializer()
 
     class Meta:
         model = Recommendation
-        fields = ('product', 'customer',)
+        fields = (
+            "product",
+            "customer",
+        )
 
 
 class ProfileSerializer(serializers.ModelSerializer):
@@ -369,13 +393,21 @@ class ProfileSerializer(serializers.ModelSerializer):
     Arguments:
         serializers
     """
+
     user = UserSerializer(many=False)
     recommends = RecommenderSerializer(many=True)
 
     class Meta:
         model = Customer
-        fields = ('id', 'url', 'user', 'phone_number',
-                  'address', 'payment_types', 'recommends',)
+        fields = (
+            "id",
+            "url",
+            "user",
+            "phone_number",
+            "address",
+            "payment_types",
+            "recommends",
+        )
         depth = 1
 
 
@@ -388,7 +420,7 @@ class FavoriteUserSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = User
-        fields = ('first_name', 'last_name', 'username')
+        fields = ("first_name", "last_name", "username")
         depth = 1
 
 
@@ -403,7 +435,11 @@ class FavoriteSellerSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Customer
-        fields = ('id', 'url', 'user',)
+        fields = (
+            "id",
+            "url",
+            "user",
+        )
         depth = 1
 
 
@@ -418,5 +454,5 @@ class FavoriteSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Favorite
-        fields = ('id', 'seller')
+        fields = ("id", "seller")
         depth = 2

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -118,8 +118,8 @@ class Profile(ViewSet):
             """
             try:
                 open_order = Order.objects.get(customer=current_user, payment_type=None)
-                line_items = OrderProduct.objects.filter(order=open_order)
-                line_items.delete()
+                lineitems = OrderProduct.objects.filter(order=open_order)
+                lineitems.delete()
                 open_order.delete()
             except Order.DoesNotExist as ex:
                 return Response(
@@ -144,9 +144,9 @@ class Profile(ViewSet):
             @apiSuccess (200) {Object} payment_type Payment Id used to complete order
             @apiSuccess (200) {String} customer URI for customer
             @apiSuccess (200) {Number} size Number of items in cart
-            @apiSuccess (200) {Object[]} line_items Line items in cart
-            @apiSuccess (200) {Number} line_items.id Line item id
-            @apiSuccess (200) {Object} line_items.product Product in cart
+            @apiSuccess (200) {Object[]} lineitems Line items in cart
+            @apiSuccess (200) {Number} lineitems.id Line item id
+            @apiSuccess (200) {Object} lineitems.product Product in cart
             @apiSuccessExample {json} Success
                 {
                     "id": 2,
@@ -154,7 +154,7 @@ class Profile(ViewSet):
                     "created_date": "2019-04-12",
                     "payment_type": null,
                     "customer": "http://localhost:8000/customers/7",
-                    "line_items": [
+                    "lineitems": [
                         {
                             "id": 4,
                             "product": {
@@ -182,17 +182,17 @@ class Profile(ViewSet):
             """
             try:
                 open_order = Order.objects.get(customer=current_user, payment_type=None)
-                line_items = OrderProduct.objects.filter(order=open_order)
-                line_items = LineItemSerializer(
-                    line_items, many=True, context={"request": request}
+                lineitems = OrderProduct.objects.filter(order=open_order)
+                lineitems = LineItemSerializer(
+                    lineitems, many=True, context={"request": request}
                 )
 
                 cart = {}
                 cart["order"] = OrderSerializer(
                     open_order, many=False, context={"request": request}
                 ).data
-                cart["order"]["line_items"] = line_items.data
-                cart["order"]["size"] = len(line_items.data)
+                cart["order"]["lineitems"] = lineitems.data
+                cart["order"]["size"] = len(lineitems.data)
 
             except Order.DoesNotExist as ex:
                 return Response(


### PR DESCRIPTION
Fixed Bug: 

> When a client requests the /profile/cart resource, the following two keys are on the response object.
>`lineitems`
>`line_items`
>The line_items key needs to be removed from the response.

## Changes

- Changed occurrences of `lineitems` to `line_items` where confusion was creating two sepearte fields with the same information

## Requests / Responses

**Request**

GET `/profile/cart` retrieves authorized users' cart contents/data

```json
{
    "id": 10,
    "url": "http://localhost:8000/orders/10",
    "created_date": "2018-11-03",
    "payment_type_name": null,
    "customer": "http://localhost:8000/customers/4",
    "total": 1655.15,
    "line_items": [
        {
            "id": 2,
            "product": {
                "id": 3,
                "name": "Optima",
                "price": 1655.15,
                "number_sold": 0,
                "description": "2008 Kia",
                "quantity": 3,
                "created_date": "2019-05-21",
                "location": "Seoul",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0
            }
        }
    ],
    "size": 1
}
```

**Response**

HTTP/1.1 201 OK


## Testing

Description of how to test code...

- [x] open Postman
- [x] GET request `http://localhost:8000/profile/json`
- [x] Use Authorization header: `Token 9ba45f09651c5b0c404f37a2d2572c026c146690`
- [x] JSON response is above


## Related Issues

- Fixes [#15](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/15)