### PR TITLE
Fixed expiration date bug for payment types

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -41,8 +41,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
This pull request addresses issue [#21](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/21). Customers have reported that the expiration date on their payment types is incorrect. Upon investigation, it was discovered that the reversal of key names for expiration date and create date during the creation process caused this discrepancy. This PR aims to rectify this issue by correcting the key names.

## Changes

- Corrected the key names for expiration date and create date during payment creation.


## Requests / Responses

**Request**

POST `/paymenttypes` Creates a new payment_type

```json
{
    "merchant_name": "Amex",
    "account_number": "fj0356fjw0g89569",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 5,
    "url": "http://localhost:8000/paymenttypes/5",
    "merchant_name": "Amex",
    "account_number": "gg5h5h5g5g5fkfkf",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

## Testing

To test code...

- [x] Open Postman
- [x] Ensure that your API is running.
- [x] Make sure you have an Authorization header with a token: `Token 9ba45f09651c5b0c404f37a2d2572c026c14669c`
- [x] Send the above POST request to `http://localhost:8000/paymenttypes` with the provided request body.
- [x] Verify that the `expiration_date` and the `create_date` match the dates in your request body.


## Related Issues

- Fixes [#21](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/21)