### PR TITLE
FIXED: All paymenttypes returning

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -88,10 +88,10 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get("customer", None)
+        customer_id = self.request.auth.user.customer.id
 
         if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+            payment_types = payment_types.filter(customer_id=customer_id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={"request": request}


### PR DESCRIPTION
GET request for `/paymenttypes` was returning all paymenttypes. Now GET request `paymenttypes` is returning only paymenttypes belonging to the authorized user. Peer testing is required.

## Changes

- `views/paymenttypes.py` line 91 now properly GET by customer_id

**Request**

GET request `/paymenttypes`

json example:
```
{
        "id": 2,
        "url": "http://localhost:8000/paymenttypes/2",
        "merchant_name": "Mastercard",
        "account_number": "39j3984fj9sofi9",
        "expiration_date": "2020-02-01",
        "create_date": "2019-12-12"
}
```

**Response**

HTTP/1.1 200 OK

## Testing

- [x] open Postman
- [x] GET request to `paymenttypes` with Authorization header: `Token 9ba45f09651c5b0c404f37a2d2572c026c146688` should return:
- [x] {
        "id": 2,
        "url": "http://localhost:8000/paymenttypes/2",
        "merchant_name": "Mastercard",
        "account_number": "39j3984fj9sofi9",
        "expiration_date": "2020-02-01",
        "create_date": "2019-12-12"
}

- [x] GET request to `paymenttypes` with Authorization header: `Token 9ba45f09651c5b0c404f37a2d2572c026c146694` should return:
- [x] {
        "id": 1,
        "url": "http://localhost:8000/paymenttypes/1",
        "merchant_name": "Visa",
        "account_number": "24ijio68948fj8439",
        "expiration_date": "2020-01-01",
        "create_date": "2019-11-11"
}


## Related Issues

- Fixes [#22](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/22)