### PR TITLE
Bug/orders/complete user orders/api

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -45,6 +45,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
             "customer",
             "total",
             "lineitems",
+            "payment_type",
         )
 
     def get_total(self, obj):
@@ -127,8 +128,14 @@ class Orders(ViewSet):
             HTTP/1.1 204 No Content
         """
         customer = Customer.objects.get(user=request.auth.user)
+
+        # Assuming request.data["payment_type"] contains the ID of the payment type
+        payment_type_id = request.data["payment_type"]
+        payment_type_instance = Payment.objects.get(pk=payment_type_id)
+
+        # Now assign the payment_type_instance to the payment_type field of the order
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type_name"]
+        order.payment_type = payment_type_instance
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -128,7 +128,7 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        order.payment_type = request.data["payment_type_name"]
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
@@ -166,9 +166,9 @@ class Orders(ViewSet):
         customer = Customer.objects.get(user=request.auth.user)
         orders = Order.objects.filter(customer=customer)
 
-        payment = self.request.query_params.get("payment_id", None)
+        payment = self.request.query_params.get("payment_type", None)
         if payment is not None:
-            orders = orders.filter(payment__id=payment)
+            orders = orders.filter(payment_id=payment)
 
         json_orders = OrderSerializer(orders, many=True, context={"request": request})
 

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -27,6 +27,7 @@ class PaymentSerializer(serializers.HyperlinkedModelSerializer):
             "account_number",
             "expiration_date",
             "create_date",
+            "customer",
         )
 
 

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -118,10 +118,16 @@ class Profile(ViewSet):
             """
             try:
                 open_order = Order.objects.get(customer=current_user, payment_type=None)
+                line_items = OrderProduct.objects.filter(order=open_order)
+                line_items.delete()
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 lineitems = OrderProduct.objects.filter(order=open_order)
                 lineitems.delete()
                 open_order.delete()
             except Order.DoesNotExist as ex:
+                return Response(
+                    {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
+                )
                 return Response(
                     {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
                 )
@@ -182,17 +188,17 @@ class Profile(ViewSet):
             """
             try:
                 open_order = Order.objects.get(customer=current_user, payment_type=None)
-                lineitems = OrderProduct.objects.filter(order=open_order)
-                lineitems = LineItemSerializer(
-                    lineitems, many=True, context={"request": request}
+                line_items = OrderProduct.objects.filter(order=open_order)
+                line_items = LineItemSerializer(
+                    line_items, many=True, context={"request": request}
                 )
 
                 cart = {}
                 cart["order"] = OrderSerializer(
                     open_order, many=False, context={"request": request}
                 ).data
-                cart["order"]["lineitems"] = lineitems.data
-                cart["order"]["size"] = len(lineitems.data)
+                cart["order"]["line_items"] = line_items.data
+                cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:
                 return Response(

--- a/bangazonapi/views/user.py
+++ b/bangazonapi/views/user.py
@@ -12,21 +12,27 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
     Arguments:
         serializers
     """
+
     class Meta:
         model = User
-        url = serializers.HyperlinkedIdentityField(
-            view_name='user',
-            lookup_field = 'id'
+        url = serializers.HyperlinkedIdentityField(view_name="user", lookup_field="id")
+        fields = (
+            "id",
+            "url",
+            "username",
+            "first_name",
+            "last_name",
+            "email",
+            "is_active",
+            "date_joined",
         )
-        fields = ('id', 'url', 'username', 'password', 'first_name', 'last_name', 'email', 'is_active', 'date_joined')
 
 
 class Users(ViewSet):
     """Users for Bangazon
     Purpose: Allow a user to communicate with the Bangazon database to GET PUT POST and DELETE Users.
     Methods: GET PUT(id) POST
-"""
-
+    """
 
     def retrieve(self, request, pk=None):
         """Handle GET requests for single customer
@@ -37,16 +43,13 @@ class Users(ViewSet):
         """
         try:
             user = User.objects.get(pk=pk)
-            serializer = UserSerializer(user, context={'request': request})
+            serializer = UserSerializer(user, context={"request": request})
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)
 
-
-
     def list(self, request):
         """Handle GET requests to user resource"""
         users = User.objects.all()
-        serializer = UserSerializer(
-            users, many=True, context={'request': request})
+        serializer = UserSerializer(users, many=True, context={"request": request})
         return Response(serializer.data)


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Changed how payment_type information was accessed during the PUT method for orders.
- Added payment_type to the order serializer


**Request**

PUT `/orders/{order_id}` Completes an order if the payment type is changed from null to an instance.

```json
{
    "payment_type": 3
}
```

**Response**

HTTP/1.1 204 No Content


## Testing

Description of how to test code...

- [x] Make sure you are using joes authentication token on postman.  ( Token 9ba45f09651c5b0c404f37a2d2572c026c146694 )
- [x] Change URL to: http://localhost:8000/orders/8
- [x] Change Method to PUT
- [x] Paste the json request body above into the body in postman. 
- [x] Send Request.
- [x] reseed database to restore the completed order. (./seed_database.sh in the command line)


## Related Issues

#fixes #45 users cant complete orders