### PR TITLE
min_price query_param returning correctly, peer testing needed

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -267,6 +267,7 @@ class Products(ViewSet):
         order = self.request.query_params.get("order_by", None)
         direction = self.request.query_params.get("direction", None)
         number_sold = self.request.query_params.get("number_sold", None)
+        min_price = self.request.query_params.get("min_price", None)
 
         if order is not None:
             order_filter = order
@@ -295,6 +296,20 @@ class Products(ViewSet):
         serializer = ProductSerializer(
             products, many=True, context={"request": request}
         )
+
+        if min_price is not None:
+
+            def min_filter(product):
+                if product.price >= int(min_price):
+                    return True
+                return False
+
+            products = filter(min_filter, products)
+
+        serializer = ProductSerializer(
+            products, many=True, context={"request": request}
+        )
+
         return Response(serializer.data)
 
     @action(methods=["post"], detail=True)


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- added logic to product.py to filter products by a minimum value

## Requests / Responses

http://localhost:8000/products?min_price=##

**Request**

GET `request http://localhost:8000/products?min_price=150`
example of a product instance with a price >= 150
```
{
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Seoul",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0
}
```

**Response**

HTTP/1.1 200 OK

## Testing



- [ ] open Postman
- [ ] GET request `GET `request http://localhost:8000/products?min_price=150`
- [ ] Confirm that all products have a price over $`150`
- [ ] One way to check is to see if product `"id": 135` is missing as it has a price of $`79.53`


## Related Issues

- Fixes [#24](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/24)