### PR TITLE
Created a test for deleting a payment type

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -62,6 +62,10 @@ class Payments(ViewSet):
             payment_type = Payment.objects.get(pk=pk)
             serializer = PaymentSerializer(payment_type, context={"request": request})
             return Response(serializer.data)
+        
+        except Payment.DoesNotExist as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
         except Exception as ex:
             return HttpResponseServerError(ex)
 

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -41,3 +41,17 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
     # TODO: Delete payment type
+
+    def test_delete_payment_type(self):
+
+        self.test_create_payment_type()
+
+        url = "/paymenttypes/1"
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.delete(url, None, format="json")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.get(url, None, format="json")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
A test was created to check the functionality of deleting a payment type. This PR completes ticket [#32](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/32)

## Changes

- Implemented a test case for deleting a payment type.
- Updated the `paymenttype` viewset to handle an additional exception: it now returns a 404 status code if the requested payment type does not exist, enhancing clarity and user experience.

## Testing

Description of how to test code...

- [x] Checkout to my branch `sg/test/delete_payment/api`
- [x] Run this line in the terminal to test `python3 manage.py test tests -v 1`
- [x] Verify that you get a similar response 
```
Found 7 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.......
----------------------------------------------------------------------
Ran 7 tests in 1.356s

OK
Destroying test database for alias 'default'...
```


## Related Issues

- Completes  [#32](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/32)