### PR TITLE
Feature: Users can create a store in order to sell items (API)

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -17,6 +17,7 @@ router.register(r"orders", Orders, "order")
 router.register(r"cart", Cart, "cart")
 router.register(r"paymenttypes", Payments, "payment")
 router.register(r"profile", Profile, "profile")
+router.register(r"stores", Stores, "store")
 
 
 # Wire up our API using automatic URL routing.

--- a/bangazonapi/models/__init__.py
+++ b/bangazonapi/models/__init__.py
@@ -8,3 +8,4 @@ from .recommendation import Recommendation
 from .rating import Rating
 from .favorite import Favorite
 from .productrating import ProductRating
+from .store import Store

--- a/bangazonapi/models/store.py
+++ b/bangazonapi/models/store.py
@@ -1,0 +1,17 @@
+from django.db import models
+from safedelete.models import SafeDeleteModel, SOFT_DELETE
+from .customer import Customer
+
+
+class Store(SafeDeleteModel):
+
+    _safedelete_policy = SOFT_DELETE
+    name = models.CharField(
+        max_length=50,
+    )
+    description = models.CharField(
+        max_length=255,
+    )
+    customer = models.ForeignKey(
+        Customer, on_delete=models.DO_NOTHING, related_name="stores"
+    )

--- a/bangazonapi/views/__init__.py
+++ b/bangazonapi/views/__init__.py
@@ -9,3 +9,4 @@ from .productcategory import ProductCategories
 from .lineitem import LineItems
 from .customer import Customers
 from .user import Users
+from .store import Stores

--- a/bangazonapi/views/customer.py
+++ b/bangazonapi/views/customer.py
@@ -8,12 +8,13 @@ from bangazonapi.models import Customer
 
 class CustomerSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customers"""
+
     class Meta:
         model = Customer
         url = serializers.HyperlinkedIdentityField(
-            view_name='customer', lookup_field='id'
+            view_name="customer", lookup_field="id"
         )
-        fields = ('id', 'url', 'user', 'phone_number', 'address')
+        fields = ("id", "url", "user", "phone_number", "address")
         depth = 1
 
 

--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -1,0 +1,74 @@
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from rest_framework import status
+from bangazonapi.models import Store, Customer
+from .product import ProductSerializer
+
+
+class StoreSerializer(serializers.ModelSerializer):
+    """JSON serializer for stores"""
+
+    # products = ProductSerializer(Many=True)
+
+    class Meta:
+        model = Store
+        fields = (
+            "id",
+            "name",
+            "description",
+            "customer",
+            # "products",
+        )
+
+
+class Stores(ViewSet):
+
+    def create(self, request):
+        """
+        @apt {POST} /stores POST new stores
+        @apiName CreateStore
+        @apiGroup Store
+        @apiHeader {String} Authorization Auth token
+        @apiHeaderExample {String} Authorization
+            Token 9ba45f09651c5b0c404f37a2d2572c026c146611
+
+        @apiParam {String} name Short form name of store
+        @apiParam {String} description Short from description of store
+        @apiParam {Number} customer_id Customer of customer
+        @apiParamExample {json} Input
+            {
+                "name": "Example Store Name",
+                "description": "Example Store Description",
+                "customer_id": 4
+            }
+        @apiSuccess (200) {Object} store Created store
+        @apiSuccess (200) {id} store.id Store Id
+        @apiSuccess (200) {String} store.name Short form name of store
+        @apiSuccess (200) {String} store.description Long form description of store
+        @apiSuccess (200) {String} store.customer_id Id of Store owner
+        @apiSuccessExample {json} Success
+            {
+                "id": 1,
+                "name": "",
+                "description": "Kite",
+                "customer" :
+                {
+                    "customer_id": "http://localhost:8000/customers/1",
+                }
+            }
+        """
+
+        new_store = Store()
+        new_store.name = request.data["name"]
+        new_store.description = request.data["description"]
+
+        customer = Customer.objects.get(user=request.auth.user)
+
+        new_store.customer = customer
+
+        new_store.save()
+
+        serializer = StoreSerializer(new_store, context={"request": request})
+
+        return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -3,13 +3,10 @@ from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
 from bangazonapi.models import Store, Customer
-from .product import ProductSerializer
 
 
 class StoreSerializer(serializers.ModelSerializer):
     """JSON serializer for stores"""
-
-    # products = ProductSerializer(Many=True)
 
     class Meta:
         model = Store
@@ -17,8 +14,7 @@ class StoreSerializer(serializers.ModelSerializer):
             "id",
             "name",
             "description",
-            "customer",
-            # "products",
+            "customer_id",
         )
 
 
@@ -55,6 +51,7 @@ class Stores(ViewSet):
                 "customer" :
                 {
                     "customer_id": "http://localhost:8000/customers/1",
+                    #! THIS EXAMPLE STORE OBJECT NEEDS COMPLETING
                 }
             }
         """

--- a/tests/order.py
+++ b/tests/order.py
@@ -120,7 +120,7 @@ class OrderTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-        # Get cart and verify product was added
+        # Get cart and verify payment was added
         url = "/orders/1"
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         response = self.client.get(url, None, format="json")
@@ -132,3 +132,11 @@ class OrderTests(APITestCase):
         )
 
     # TODO: New line item is not added to closed order
+
+    def test_add_product_to_open_order_only(self):
+
+        self.test_add_product_to_order()
+
+        self.test_add_payment_type_to_order()
+
+        self.test_add_product_to_order()


### PR DESCRIPTION
Added functionality to create/POST new store to database

## Changes

- created `models/store.py`
- created `views.store.py`
- added Store viewset with a CREATE/POST

## Requests / Responses

new store JSON example :
```
{
    "id": 4,
    "name": "Steve's Store",
    "description": "My store is fun",
    "customer_id": 4
}
```

**Request**

POST `http://localhost:8000/stores`

**Response**

HTTP/1.1 201 OK

## Testing

Description of how to test code...

- [x] open terminal
- [x] navigate to api project workspace
- [x] command `./seed_data.sh`
- [x] open Postman
- [x] POST `http://localhost:8000/stores`
- [x] verify json Response:
```
{
    "id": 1,
    "name": "store name",
    "description": "store description",
    "customer_id": #
}
```
- [x] verify store is added to database


## Related Issues

- Fixes [#33}(https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/35)