### PR TITLE
Fixed exception in the profile/cart GET to not throw error when no store

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -284,10 +284,10 @@ class Profile(ViewSet):
                 return Response(serializer.data)
 
             except Store.DoesNotExist:
-                pass
-                # return Response(
-                #     {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
-                # )
+                return Response(
+                    {"message": "Store does not exist"},
+                    status=status.HTTP_204_NO_CONTENT,
+                )
 
     @action(methods=["get"], detail=False)
     def favoritesellers(self, request):


### PR DESCRIPTION
This pull request addresses a bug identified in ticket [#57](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/57). The issue involved unintended error propagation to the client when encountering a non-existent store. The proposed fix ensures that the application gracefully handles the scenario where the store does not exist, preventing any disruptions in functionality.

## Changes

- Changed from pass to a 204 response


## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET`/profile/store` Gets user's store


**Response**

HTTP/1.1 204 OK

```json
{
    "message": "Store does not exist"
}
```

## Testing

Description of how to test code...

- [ ]  Seed database to make the database have no stores
- [ ] perform a GET to `http://localhost:8000/profile/store` in postman
- [ ] response should be similar to above and not a 500 error


## Related Issues

- Contributes to ticket [#57](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/57)