### PR TITLE
implemented full clean method when invoking validators

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -18,7 +18,7 @@ class Product(SafeDeleteModel):
         Customer, on_delete=models.DO_NOTHING, related_name="products"
     )
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],
+        validators=[MinValueValidator(0.00), MaxValueValidator(17500.00)],
     )
     description = models.CharField(
         max_length=255,

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -12,6 +12,7 @@ from rest_framework import status
 from bangazonapi.models import Product, Customer, ProductCategory
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.parsers import MultiPartParser, FormParser
+from django.core.exceptions import ValidationError
 
 
 class ProductSerializer(serializers.ModelSerializer):
@@ -120,6 +121,11 @@ class Products(ViewSet):
             )
 
             new_product.image_path = data
+        try:
+            new_product.full_clean()
+
+        except ValidationError as e:
+            return Response({"error": e.messages}, status=status.HTTP_400_BAD_REQUEST)
 
         new_product.save()
 


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Changed argument of 10000 in max price validator to 17500
- Implemented full_clean() method when invoking validator so that logic isnt ignored.

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/products` Creates a new product

```json
Click createProudct (json body) and change the price property to $17500
```

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 150,
    "name": "Kite",
    "price": 17500.0,
    "number_sold": 0,
    "description": "It flies high",
    "quantity": 60,
    "created_date": "2024-04-05",
    "location": "Pittsburgh",
    "image_path": "http://localhost:8000/media/products/None-Kite.jpeg",
    "average_rating": 0,
    "category": {
        "id": 6,
        "name": "Games/Toys"
    }
}
```

## Testing

Description of how to test code...

- [x] Run migrations
- [x] Change method to POST and url to /products
- [x] Paste the brief JSON body above into the body
- [x] Insure you get 201 as a response 


## Related Issues

- Fixes #26
