### PR TITLE
FIXED: BUG: Add payment method not posting to database (API)

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -1,5 +1,6 @@
 """View module for handling requests about customer payment types"""
 
+import datetime
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
@@ -43,7 +44,7 @@ class Payments(ViewSet):
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
         new_payment.expiration_date = request.data["expiration_date"]
-        new_payment.create_date = request.data["create_date"]
+        new_payment.create_date = datetime.date.today()
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()
@@ -62,7 +63,7 @@ class Payments(ViewSet):
             payment_type = Payment.objects.get(pk=pk)
             serializer = PaymentSerializer(payment_type, context={"request": request})
             return Response(serializer.data)
-        
+
         except Payment.DoesNotExist as ex:
             return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 


### PR DESCRIPTION
Fixed functionality to add payment type via POST

## Changes

- added `datetime.dte.today()` to create `create_date` via the backend, rather than generating a date fro the front end

## Requests / Response

POST `/paymenttypes` Creates a new paymenttype

json REQUEST example:
````
{
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
````

json RESPONSE example:
```
{
    "id": 6,
    "url": "http://localhost:8000/paymenttypes/6",
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2024-04-08",
    "customer": "http://localhost:8000/customers/4"
}
```
## Testing

Description of how to test code...

- [x] open terminal, cd to api project folder
- [x] command `./seed_data.sh` to reseed database
- [x] open Postman
- [x] in lefthand nav column, select `POST create a payment type`
- [x] all headers and body will populate with info for user `steve`
- [x] send POST
- [x] confirm database updates correctly with new payment type


## Related Issues

- Fixes #19 