### PR TITLE
FIXED: BUG: Product rating not posting to database

### DIFF
--- a/bangazonapi/fixtures/productrating.json
+++ b/bangazonapi/fixtures/productrating.json
@@ -5,7 +5,8 @@
     "fields": {
       "product": 50,
       "customer": 4,
-      "rating": 4
+      "rating": 2,
+      "review": "This car is a LEMON"
     }
   },
   {
@@ -14,7 +15,8 @@
     "fields": {
       "product": 50,
       "customer": 5,
-      "rating": 3
+      "rating": 1,
+      "review": "I can even get the thing started!"
     }
   },
   {
@@ -23,7 +25,8 @@
     "fields": {
       "product": 50,
       "customer": 6,
-      "rating": 5
+      "rating": 2,
+      "review": "What a hunk-o-junk"
     }
   },
   {
@@ -32,7 +35,8 @@
     "fields": {
       "product": 50,
       "customer": 7,
-      "rating": 1
+      "rating": 1,
+      "review": "Rust everywhere!!"
     }
   }
 ]

--- a/bangazonapi/models/productrating.py
+++ b/bangazonapi/models/productrating.py
@@ -5,13 +5,20 @@ from .customer import Customer
 
 class ProductRating(models.Model):
 
-    product = models.ForeignKey("Product", on_delete=models.CASCADE, related_name="ratings")
+    product = models.ForeignKey(
+        "Product", on_delete=models.CASCADE, related_name="ratings"
+    )
     customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
-    rating = models.IntegerField(validators=[MinValueValidator(0), MaxValueValidator(5)])
+    rating = models.IntegerField(
+        validators=[MinValueValidator(0), MaxValueValidator(5)]
+    )
+    review = models.CharField(max_length=255)
+
 
 class Meta:
-    verbose_name = ("productrating")
-    verbose_name_plural = ("productratings")
+    verbose_name = "productrating"
+    verbose_name_plural = "productratings"
+
 
 def __str__(self):
     return self.rating

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -10,7 +10,7 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
-from bangazonapi.models import Product, Customer, ProductCategory
+from bangazonapi.models import Product, Customer, ProductCategory, ProductRating
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.parsers import MultiPartParser, FormParser
 from django.core.exceptions import ValidationError
@@ -326,6 +326,22 @@ class Products(ViewSet):
         )
 
         return Response(serializer.data)
+
+    @action(methods=["post"], detail=True)
+    def rate_product(self, request, pk=None):
+
+        if request.method == "POST":
+            rate = ProductRating()
+            rate.product = Product.objects.get(pk=pk)
+            rate.customer = Customer.objects.get(user=request.auth.user)
+            rate.rating = request.data["rating"]
+            rate.review = request.data["review"]
+
+            rate.save()
+
+            return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+        return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
     @action(methods=["post"], detail=True)
     def recommend(self, request, pk=None):


### PR DESCRIPTION
Fixed bug where product rating does not post to data base

## Changes

- added a POST @action for `products/##/rate_product`

json REQUEST example:
```
{
    "rating": 1,
    "review": "utter junk"
}
```

**Response**

HTTP/1.1 204 No Content

## Testing

Description of how to test code...

- [x] open terminal
- [x] navigate to api project folder
- [x] command `./seed_data.sh` to reseed database with updated product rating data
- [ ] open Postman
- [ ] POST ` http://localhost:8000/products/50/rate_product` with example json REQUEST above
- [ ] confirm a response of 204 and confirm database updates correctly


## Related Issues

- Fixes [#66](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-client-bangazon-team-3/issues/66)